### PR TITLE
Fix clipped terminal text in session view

### DIFF
--- a/Packages/SpecttyUI/Sources/SpecttyUI/GestureHandler.swift
+++ b/Packages/SpecttyUI/Sources/SpecttyUI/GestureHandler.swift
@@ -167,10 +167,9 @@ public final class GestureHandler: NSObject {
         guard let metalView = metalView else { return }
 
         let point = gesture.location(in: metalView)
-        let cellSize = metalView.cellSize
-        let grid = metalView.gridSize
-        let col = max(0, min(Int(point.x / cellSize.width), grid.columns - 1))
-        let row = max(0, min(Int(point.y / cellSize.height), grid.rows - 1))
+        let coord = metalView.gridCoordinate(for: point)
+        let row = coord.row
+        let col = coord.col
 
         switch gesture.state {
         case .began:
@@ -212,13 +211,10 @@ public final class GestureHandler: NSObject {
     private func requestMenu() {
         guard let sel = currentSelection else { return }
         guard let metalView = metalView else { return }
-        let cellSize = metalView.cellSize
         let norm = sel.normalized
 
         let midRow = (norm.startRow + norm.endRow) / 2
-        let centerX = CGFloat(norm.startCol + norm.endCol + 1) / 2.0 * cellSize.width
-        let centerY = CGFloat(midRow) * cellSize.height + cellSize.height / 2.0
-        onShowMenu?(CGPoint(x: centerX, y: centerY))
+        onShowMenu?(metalView.selectionCenterPoint(row: midRow, startCol: norm.startCol, endCol: norm.endCol))
     }
 
     /// Update the tracked selection (e.g. when handles are dragged externally).

--- a/Packages/SpecttyUI/Sources/SpecttyUI/TerminalMetalRenderer.swift
+++ b/Packages/SpecttyUI/Sources/SpecttyUI/TerminalMetalRenderer.swift
@@ -18,7 +18,13 @@ public struct TerminalFont: Sendable {
 
 /// Protocol for terminal renderers (allows swapping Metal impl for libghostty's renderer).
 public protocol TerminalRenderer: AnyObject {
-    func update(state: TerminalScreenState, scrollback: TerminalBuffer, scrollOffset: Int, viewportSize: CGSize)
+    func update(
+        state: TerminalScreenState,
+        scrollback: TerminalBuffer,
+        scrollOffset: Int,
+        viewportSize: CGSize,
+        contentRect: CGRect
+    )
     func setFont(_ font: TerminalFont)
     var cellSize: CGSize { get }
 }
@@ -305,7 +311,13 @@ public final class TerminalMetalRenderer: TerminalRenderer {
 
     // MARK: - Update State
 
-    public func update(state: TerminalScreenState, scrollback: TerminalBuffer, scrollOffset: Int, viewportSize: CGSize) {
+    public func update(
+        state: TerminalScreenState,
+        scrollback: TerminalBuffer,
+        scrollOffset: Int,
+        viewportSize: CGSize,
+        contentRect: CGRect
+    ) {
         // Build vertex data for all visible cells.
         var vertices: [CellVertex] = []
         vertices.reserveCapacity(state.columns * state.rows * 6) // 6 vertices per cell (2 triangles)
@@ -317,6 +329,8 @@ public final class TerminalMetalRenderer: TerminalRenderer {
         let viewH = max(Float(viewportSize.height), 1)
         let cellW = Float(_cellSize.width)
         let cellH = Float(_cellSize.height)
+        let originX = Float(contentRect.minX)
+        let originY = Float(contentRect.minY)
 
         for row in 0..<state.rows {
             let lineIndex: Int
@@ -372,8 +386,8 @@ public final class TerminalMetalRenderer: TerminalRenderer {
                 )
 
                 // Position in pixel coordinates (top-left origin).
-                let x0 = Float(col) * cellW
-                let y0 = Float(row) * cellH
+                let x0 = originX + Float(col) * cellW
+                let y0 = originY + Float(row) * cellH
                 let x1 = x0 + cellW
                 let y1 = y0 + cellH
 
@@ -409,8 +423,8 @@ public final class TerminalMetalRenderer: TerminalRenderer {
             let cursorRow = state.cursor.row
             let cursorCol = state.cursor.col
             if cursorRow >= 0 && cursorRow < state.rows && cursorCol >= 0 && cursorCol < state.columns {
-                let x0 = Float(cursorCol) * cellW
-                let y0 = Float(cursorRow) * cellH
+                let x0 = originX + Float(cursorCol) * cellW
+                let y0 = originY + Float(cursorRow) * cellH
 
                 // Compute cursor rect based on style.
                 let cursorX0: Float

--- a/Packages/SpecttyUI/Sources/SpecttyUI/TerminalMetalView.swift
+++ b/Packages/SpecttyUI/Sources/SpecttyUI/TerminalMetalView.swift
@@ -34,6 +34,9 @@ public final class TerminalMetalView: MTKView, UIKeyInput {
     /// Current font configuration.
     public private(set) var terminalFont = TerminalFont()
 
+    /// Built-in text gutter so terminal glyphs do not touch view edges.
+    private let terminalContentInsets = UIEdgeInsets(top: 3, left: 6, bottom: 3, right: 6)
+
     /// Gesture handler for scroll, pinch, selection.
     private var gestureHandler: GestureHandler?
 
@@ -81,6 +84,8 @@ public final class TerminalMetalView: MTKView, UIKeyInput {
 
         // Selection overlay — hit tests only near drag handles, passes through otherwise.
         selectionView.frame = bounds
+        selectionView.contentInsets = terminalContentInsets
+        selectionView.cellSize = cellSize
         addSubview(selectionView)
 
         // Edit menu interaction for copy/paste — nil delegate uses default
@@ -430,13 +435,42 @@ public final class TerminalMetalView: MTKView, UIKeyInput {
         renderer?.cellSize ?? CGSize(width: 8, height: 17)
     }
 
+    /// Drawable content rect after applying terminal insets.
+    var terminalContentRect: CGRect {
+        let rect = bounds.inset(by: terminalContentInsets)
+        guard rect.width > 0, rect.height > 0 else { return .zero }
+        return rect
+    }
+
     public var gridSize: (columns: Int, rows: Int) {
         guard let renderer = renderer else { return (80, 24) }
         let cellSize = renderer.cellSize
         guard cellSize.width > 0, cellSize.height > 0 else { return (80, 24) }
-        let columns = max(1, Int(bounds.width / cellSize.width))
-        let rows = max(1, Int(bounds.height / cellSize.height))
+        let rect = terminalContentRect
+        guard rect.width > 0, rect.height > 0 else { return (80, 24) }
+        let columns = max(1, Int(rect.width / cellSize.width))
+        let rows = max(1, Int(rect.height / cellSize.height))
         return (columns, rows)
+    }
+
+    /// Convert a point in view coordinates to a clamped terminal grid coordinate.
+    func gridCoordinate(for point: CGPoint) -> (row: Int, col: Int) {
+        let grid = gridSize
+        guard grid.columns > 0, grid.rows > 0 else { return (0, 0) }
+        let rect = terminalContentRect.isEmpty ? bounds : terminalContentRect
+        let localX = point.x - rect.minX
+        let localY = point.y - rect.minY
+        let col = max(0, min(Int(localX / cellSize.width), grid.columns - 1))
+        let row = max(0, min(Int(localY / cellSize.height), grid.rows - 1))
+        return (row, col)
+    }
+
+    /// Center point for a row/column selection in view coordinates.
+    func selectionCenterPoint(row: Int, startCol: Int, endCol: Int) -> CGPoint {
+        let rect = terminalContentRect.isEmpty ? bounds : terminalContentRect
+        let centerX = rect.minX + CGFloat(startCol + endCol + 1) / 2.0 * cellSize.width
+        let centerY = rect.minY + CGFloat(row) * cellSize.height + cellSize.height / 2.0
+        return CGPoint(x: centerX, y: centerY)
     }
 
     private func notifyResizeIfNeeded() {
@@ -467,6 +501,8 @@ public final class TerminalMetalView: MTKView, UIKeyInput {
     public override func layoutSubviews() {
         super.layoutSubviews()
         selectionView.frame = bounds
+        selectionView.contentInsets = terminalContentInsets
+        selectionView.cellSize = cellSize
         bellLayer?.frame = bounds
         notifyResizeIfNeeded()
     }
@@ -524,8 +560,13 @@ extension TerminalMetalView: MTKViewDelegate {
         else { return }
 
         let state = emulator.state.activeScreen
-        renderer.update(state: state, scrollback: emulator.state.scrollback, scrollOffset: scrollOffset, viewportSize: bounds.size)
+        renderer.update(
+            state: state,
+            scrollback: emulator.state.scrollback,
+            scrollOffset: scrollOffset,
+            viewportSize: bounds.size,
+            contentRect: terminalContentRect
+        )
         renderer.render(to: renderPassDescriptor, drawable: drawable)
     }
 }
-

--- a/Packages/SpecttyUI/Sources/SpecttyUI/TextSelectionView.swift
+++ b/Packages/SpecttyUI/Sources/SpecttyUI/TextSelectionView.swift
@@ -52,6 +52,9 @@ public final class TextSelectionView: UIView {
 
     public var cellSize: CGSize = CGSize(width: 8, height: 16)
     public var selectionColor: UIColor = UIColor.systemBlue.withAlphaComponent(0.3)
+    public var contentInsets: UIEdgeInsets = .zero {
+        didSet { setNeedsDisplay() }
+    }
 
     // MARK: - Handle drag state
 
@@ -94,6 +97,31 @@ public final class TextSelectionView: UIView {
 
     // MARK: - Hit Testing
 
+    private var contentRect: CGRect {
+        let width = max(0, bounds.width - contentInsets.left - contentInsets.right)
+        let height = max(0, bounds.height - contentInsets.top - contentInsets.bottom)
+        return CGRect(x: contentInsets.left, y: contentInsets.top, width: width, height: height)
+    }
+
+    private var gridColumns: Int {
+        guard cellSize.width > 0 else { return 1 }
+        return max(1, Int(contentRect.width / cellSize.width))
+    }
+
+    private var gridRows: Int {
+        guard cellSize.height > 0 else { return 1 }
+        return max(1, Int(contentRect.height / cellSize.height))
+    }
+
+    private func clampedGridCoordinate(for point: CGPoint) -> (row: Int, col: Int) {
+        guard cellSize.width > 0, cellSize.height > 0 else { return (0, 0) }
+        let localX = point.x - contentRect.minX
+        let localY = point.y - contentRect.minY
+        let col = max(0, min(Int(localX / cellSize.width), gridColumns - 1))
+        let row = max(0, min(Int(localY / cellSize.height), gridRows - 1))
+        return (row, col)
+    }
+
     /// Only intercept touches near a drag handle. Everything else passes through
     /// to the terminal view underneath.
     public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
@@ -115,16 +143,18 @@ public final class TextSelectionView: UIView {
 
     /// Center point of a handle in view coordinates.
     private func handleCenter(for sel: TerminalSelection, handle: DragHandle) -> CGPoint {
+        let originX = contentRect.minX
+        let originY = contentRect.minY
         switch handle {
         case .start:
             // Top-left of the start cell, handle sits above the selection.
-            let x = CGFloat(sel.startCol) * cellSize.width
-            let y = CGFloat(sel.startRow) * cellSize.height
+            let x = originX + CGFloat(sel.startCol) * cellSize.width
+            let y = originY + CGFloat(sel.startRow) * cellSize.height
             return CGPoint(x: x, y: y - handleStemHeight - handleRadius)
         case .end:
             // Bottom-right of the end cell, handle sits below the selection.
-            let x = CGFloat(sel.endCol + 1) * cellSize.width
-            let y = CGFloat(sel.endRow + 1) * cellSize.height
+            let x = originX + CGFloat(sel.endCol + 1) * cellSize.width
+            let y = originY + CGFloat(sel.endRow + 1) * cellSize.height
             return CGPoint(x: x, y: y + handleStemHeight + handleRadius)
         }
     }
@@ -153,18 +183,18 @@ public final class TextSelectionView: UIView {
                 endCol = selection.endCol
             } else if row == selection.startRow {
                 startCol = selection.startCol
-                endCol = Int(bounds.width / cellSize.width)
+                endCol = gridColumns - 1
             } else if row == selection.endRow {
                 startCol = 0
                 endCol = selection.endCol
             } else {
                 startCol = 0
-                endCol = Int(bounds.width / cellSize.width)
+                endCol = gridColumns - 1
             }
 
             let rect = CGRect(
-                x: CGFloat(startCol) * cellSize.width,
-                y: CGFloat(row) * cellSize.height,
+                x: contentRect.minX + CGFloat(startCol) * cellSize.width,
+                y: contentRect.minY + CGFloat(row) * cellSize.height,
                 width: CGFloat(endCol - startCol + 1) * cellSize.width,
                 height: cellSize.height
             )
@@ -183,15 +213,15 @@ public final class TextSelectionView: UIView {
         switch handle {
         case .start:
             // Stem from top-left of start cell down to circle.
-            let anchorX = CGFloat(selection.startCol) * cellSize.width
-            let anchorY = CGFloat(selection.startRow) * cellSize.height
+            let anchorX = contentRect.minX + CGFloat(selection.startCol) * cellSize.width
+            let anchorY = contentRect.minY + CGFloat(selection.startRow) * cellSize.height
             ctx.move(to: CGPoint(x: anchorX, y: anchorY))
             ctx.addLine(to: CGPoint(x: center.x, y: center.y + handleRadius))
             ctx.strokePath()
         case .end:
             // Stem from bottom-right of end cell up to circle.
-            let anchorX = CGFloat(selection.endCol + 1) * cellSize.width
-            let anchorY = CGFloat(selection.endRow + 1) * cellSize.height
+            let anchorX = contentRect.minX + CGFloat(selection.endCol + 1) * cellSize.width
+            let anchorY = contentRect.minY + CGFloat(selection.endRow + 1) * cellSize.height
             ctx.move(to: CGPoint(x: anchorX, y: anchorY))
             ctx.addLine(to: CGPoint(x: center.x, y: center.y - handleRadius))
             ctx.strokePath()
@@ -213,8 +243,9 @@ public final class TextSelectionView: UIView {
         guard var sel = selection?.normalized else { return }
 
         let point = gesture.location(in: self)
-        let col = max(0, min(Int(point.x / cellSize.width), Int(bounds.width / cellSize.width) - 1))
-        let row = max(0, min(Int(point.y / cellSize.height), Int(bounds.height / cellSize.height) - 1))
+        let coord = clampedGridCoordinate(for: point)
+        let row = coord.row
+        let col = coord.col
 
         switch gesture.state {
         case .began:
@@ -254,8 +285,8 @@ public final class TextSelectionView: UIView {
             // Show copy menu after handle drag finishes.
             if gesture.state == .ended, let sel = selection?.normalized {
                 let midRow = (sel.startRow + sel.endRow) / 2
-                let centerX = CGFloat(sel.startCol + sel.endCol + 1) / 2.0 * cellSize.width
-                let centerY = CGFloat(midRow) * cellSize.height + cellSize.height / 2.0
+                let centerX = contentRect.minX + CGFloat(sel.startCol + sel.endCol + 1) / 2.0 * cellSize.width
+                let centerY = contentRect.minY + CGFloat(midRow) * cellSize.height + cellSize.height / 2.0
                 onShowMenu?(CGPoint(x: centerX, y: centerY))
             }
 


### PR DESCRIPTION
## Summary
- add built-in terminal content insets so the first row and left edge do not clip
- keep grid sizing, selection, and edit menu positioning aligned with the inset content rect
- tighten the renderer interface to accept resolved content geometry instead of inset policy

## Testing
- xcodebuild -project Spectty.xcodeproj -scheme Spectty -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build

Fixes #6